### PR TITLE
Experiment 2 - Use early stopping in CatBoost

### DIFF
--- a/experiments/experiment_2/accuracy.ipynb
+++ b/experiments/experiment_2/accuracy.ipynb
@@ -16,6 +16,7 @@
     "from catboost import CatBoostRegressor\n",
     "from sklearn.model_selection import train_test_split\n",
     "from sklearn.metrics import r2_score\n",
+    "import matplotlib.pyplot as plt\n",
     "\n",
     "from experiment_2 import utils\n",
     "from data.benchmark_selection import ksg_selection, hsic_selection, boruta_selection\n",
@@ -25,21 +26,39 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "c5766ecf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset_path = 'data/exp2.csv' # or 'data/exp2filtered.csv'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "7dbbcd27",
    "metadata": {},
    "outputs": [],
    "source": [
-    "xdf, ydf, float_features, cat_features, targets = utils.load_data()\n",
+    "xdf, ydf, float_features, cat_features, targets = utils.load_data(dataset_path)\n",
     "X_train, X_test, y_train, y_test = train_test_split(\n",
     "    xdf,\n",
     "    ydf,\n",
+    "    test_size=0.2,\n",
+    "    random_state=None\n",
+    ")\n",
+    "X_train, X_val, y_train, y_val = train_test_split(\n",
+    "    xdf,\n",
+    "    ydf,\n",
     "    test_size=0.3,\n",
-    "    random_state=40\n",
-    ")   \n",
+    "    random_state=None\n",
+    ")\n",
     "print(f'X_train.shape: {X_train.shape}')\n",
+    "print(f'X_val.shape: {X_val.shape}')\n",
     "print(f'X_test.shape: {X_test.shape}')\n",
     "print(f'y_train.shape: {y_train.shape}')\n",
-    "print(f'y_test.shape: {y_test.shape}')\n"
+    "print(f'y_val.shape: {y_val.shape}')\n",
+    "print(f'y_test.shape: {y_test.shape}')"
    ]
   },
   {
@@ -58,11 +77,33 @@
    "outputs": [],
    "source": [
     "params = { \n",
-    "    \"iterations\": 200,\n",
+    "    \"iterations\": 5000,\n",
     "    \"depth\": 8,\n",
     "    'random_state': 15, \n",
     "    'verbose': False\n",
     "}   "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "47872d45",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def train_and_evaluate(X_train, y_train, X_val, y_val, X_test, y_test, selection=None):\n",
+    "    if selection is None:\n",
+    "        selection = X_train.columns.tolist()\n",
+    "    x_train = X_train.loc[:, selection].copy()\n",
+    "    x_val = X_val.loc[:, selection].copy()\n",
+    "    x_test = X_test.loc[:, selection].copy()\n",
+    "    model = CatBoostRegressor(**params)\n",
+    "    model.fit(x_train, y_train, eval_set=(x_val, y_val), early_stopping_rounds=20)\n",
+    "    train_predictions = model.predict(x_train)\n",
+    "    test_predictions = model.predict(x_test)\n",
+    "    r2_insample = r2_score(y_true=y_train, y_pred=train_predictions)\n",
+    "    r2_outsample = r2_score(y_true=y_test, y_pred=test_predictions)\n",
+    "    return r2_insample, r2_outsample"
    ]
   },
   {
@@ -77,17 +118,19 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "248746e3",
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
-    "model = CatBoostRegressor(**params)\n",
-    "model.fit(X_train, y_train)\n",
-    "train_predictions = model.predict(X_train)\n",
-    "test_predictions = model.predict(X_test)\n",
-    "r2_insample = r2_score(y_true=y_train, y_pred=train_predictions)\n",
-    "r2_outsample = r2_score(y_true=y_test, y_pred=test_predictions)\n",
+    "r2_insample, r2_outsample = train_and_evaluate(\n",
+    "    X_train, y_train,\n",
+    "    X_val, y_val,\n",
+    "    X_test, y_test,\n",
+    "    selection=None\n",
+    ")\n",
     "print(f'In-sample R2 score: {r2_insample}')\n",
-    "print(f'Out-sample R2 score: {r2_outsample}')\n"
+    "print(f'Out-sample R2 score: {r2_outsample}')"
    ]
   },
   {
@@ -105,14 +148,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "X_train_ksg = X_train.loc[:, ksg_selection]\n",
-    "X_test_ksg = X_test.loc[:, ksg_selection]\n",
-    "model_ksg = CatBoostRegressor(**params)\n",
-    "model_ksg.fit(X_train_ksg, y_train)\n",
-    "train_predictions_ksg = model_ksg.predict(X_train_ksg)\n",
-    "test_predictions_ksg = model_ksg.predict(X_test_ksg)\n",
-    "r2_insample_ksg = r2_score(y_true=y_train, y_pred=train_predictions_ksg)\n",
-    "r2_outsample_ksg = r2_score(y_true=y_test, y_pred=test_predictions_ksg)\n",
+    "r2_insample_ksg, r2_outsample_ksg = train_and_evaluate(\n",
+    "    X_train, y_train,\n",
+    "    X_val, y_val,\n",
+    "    X_test, y_test,\n",
+    "    selection=ksg_selection,\n",
+    ")\n",
     "print(f'In-sample R2 score with KSG selection: {r2_insample_ksg}')\n",
     "print(f'Out-sample R2 score with KSG selection: {r2_outsample_ksg}')"
    ]
@@ -132,16 +173,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    " X_train_hsic = X_train.loc[:, hsic_selection]\n",
-    "X_test_hsic = X_test.loc[:, hsic_selection]\n",
-    "model_hsic = CatBoostRegressor(**params)\n",
-    "model_hsic.fit(X_train_hsic, y_train)\n",
-    "train_predictions_hsic = model_hsic.predict(X_train_hsic)\n",
-    "test_predictions_hsic = model_hsic.predict(X_test_hsic)\n",
-    "r2_insample_hsic = r2_score(y_true=y_train, y_pred=train_predictions_hsic)\n",
-    "r2_outsample_hsic = r2_score(y_true=y_test, y_pred=test_predictions_hsic)\n",
+    "r2_insample_hsic, r2_outsample_hsic = train_and_evaluate(\n",
+    "    X_train, y_train,\n",
+    "    X_val, y_val,\n",
+    "    X_test, y_test,\n",
+    "    selection=hsic_selection,\n",
+    ")\n",
     "print(f'In-sample R2 score: {r2_insample_hsic}')\n",
-    "print(f'Out-sample R2 score: {r2_outsample_hsic}')\n"
+    "print(f'Out-sample R2 score: {r2_outsample_hsic}')"
    ]
   },
   {
@@ -159,18 +198,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "X_train_boruta = X_train.loc[:, boruta_selection]\n",
-    "X_test_boruta = X_test.loc[:, boruta_selection]\n",
-    "model_boruta = CatBoostRegressor(**params)\n",
-    "model_boruta.fit(X_train_boruta, y_train)\n",
-    "train_predictions_boruta = model_boruta.predict(X_train_boruta)\n",
-    "test_predictions_boruta = model_boruta.predict(X_test_boruta)\n",
-    "r2_insample_boruta = r2_score(\n",
-    "    y_true=y_train, y_pred=train_predictions_boruta)\n",
-    "r2_outsample_boruta = r2_score(\n",
-    "    y_true=y_test, y_pred=test_predictions_boruta)\n",
+    "r2_insample_boruta, r2_outsample_boruta = train_and_evaluate(\n",
+    "    X_train, y_train,\n",
+    "    X_val, y_val,\n",
+    "    X_test, y_test,\n",
+    "    selection=boruta_selection,\n",
+    ")\n",
     "print(f'In-sample R2 score: {r2_insample_boruta}')\n",
-    "print(f'Out-sample R2 score: {r2_outsample_boruta}')\n"
+    "print(f'Out-sample R2 score: {r2_outsample_boruta}')"
    ]
   },
   {
@@ -188,18 +223,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "X_train_minerva = X_train.loc[:, minerva_selection_1]\n",
-    "X_test_minerva = X_test.loc[:, minerva_selection_1]\n",
-    "model_minerva = CatBoostRegressor(**params)\n",
-    "model_minerva.fit(X_train_minerva, y_train)\n",
-    "train_predictions_minerva = model_minerva.predict(X_train_minerva)\n",
-    "test_predictions_minerva = model_minerva.predict(X_test_minerva)\n",
-    "r2_insample_minerva = r2_score(\n",
-    "    y_true=y_train, y_pred=train_predictions_minerva)\n",
-    "r2_outsample_minerva = r2_score(\n",
-    "    y_true=y_test, y_pred=test_predictions_minerva)\n",
+    "r2_insample_minerva, r2_outsample_minerva = train_and_evaluate(\n",
+    "    X_train, y_train,\n",
+    "    X_val, y_val,\n",
+    "    X_test, y_test,\n",
+    "    selection=minerva_selection_1\n",
+    ")\n",
     "print(f'In-sample R2 score: {r2_insample_minerva}')\n",
-    "print(f'Out-sample R2 score: {r2_outsample_minerva}')\n"
+    "print(f'Out-sample R2 score: {r2_outsample_minerva}')"
    ]
   },
   {

--- a/experiments/experiment_2/accuracy.py
+++ b/experiments/experiment_2/accuracy.py
@@ -27,50 +27,68 @@ from data.minerva_selection import (
     minerva_selection_1_adjusted,
 )
 
+# ### CatBoost parameters
+random_state = np.random.randint(low=0, high=100)
+print(f'Random state used in CatBoostRegressor: {random_state}')
+catboost_params = {
+    "iterations": 10000,  # Early stopping will reduce this number of iterations
+    "depth": 8,
+    'random_state': random_state,
+    'verbose': False
+}
 
-def main():
+
+def train_and_evaluate(X_train, y_train, X_val, y_val, X_test, y_test, selection=None):
+    if selection is None:
+        selection = X_train.columns.tolist()
+    x_train = X_train.loc[:, selection].copy()
+    x_val = X_val.loc[:, selection].copy()
+    x_test = X_test.loc[:, selection].copy()
+    model = CatBoostRegressor(**catboost_params)
+    model.fit(x_train, y_train, eval_set=(
+        x_val, y_val), early_stopping_rounds=20)
+    train_predictions = model.predict(x_train)
+    test_predictions = model.predict(x_test)
+    r2_insample = r2_score(y_true=y_train, y_pred=train_predictions)
+    r2_outsample = r2_score(y_true=y_test, y_pred=test_predictions)
+    return r2_insample, r2_outsample
+
+
+def main(dataset_path='data/exp2filtered.csv'):  # or 'data/exp2.csv'):
     xdf, ydf, float_features, cat_features, targets = utils.load_data(
-        'data/exp2filtered.csv')
+        dataset_path)
     X_train, X_test, y_train, y_test = train_test_split(
         xdf,
         ydf,
-        test_size=0.3,
-        random_state=40
+        test_size=0.2,
+        random_state=None
     )
-    # ### CatBoost parameters
-    # random_state = 15 gives good R2 scores for Minerva selection 1
-    # random_state = 3 or 9 gives good R2 scores for adjusted Minerva selection 1
-    # random_state = 1 gives bad R2 scores for Boruta and good R2 scores for Minerva selection 1
-    random_state = np.random.randint(low=0, high=100)
-    print(f'Random state used in CatBoostRegressor: {random_state}')
-    params = {
-        "iterations": 200,
-        "depth": 8,
-        'random_state': random_state,
-        'verbose': False
-    }
+    X_train, X_val, y_train, y_val = train_test_split(
+        xdf,
+        ydf,
+        test_size=0.3,
+        random_state=None
+    )
 
     # ## Accuracy of prediction based on all features
-    model = CatBoostRegressor(**params)
-    model.fit(X_train, y_train)
-    train_predictions = model.predict(X_train)
-    test_predictions = model.predict(X_test)
-    r2_insample = r2_score(y_true=y_train, y_pred=train_predictions)
-    r2_outsample = r2_score(y_true=y_test, y_pred=test_predictions)
+    r2_insample, r2_outsample = train_and_evaluate(
+        X_train, y_train,
+        X_val, y_val,
+        X_test, y_test,
+        selection=None
+    )
     print('\nAll features - No selection')
     print(f'Number of features: {X_train.shape[1]}')
     print(f'In-sample R2 score: {round(r2_insample, 4)}')
     print(f'Out-sample R2 score: {round(r2_outsample, 4)}')
 
     # ## Accuracy of prediction based on KSG selection
-    X_train_ksg = X_train.loc[:, ksg_selection]
-    X_test_ksg = X_test.loc[:, ksg_selection]
-    model_ksg = CatBoostRegressor(**params)
-    model_ksg.fit(X_train_ksg, y_train)
-    train_predictions_ksg = model_ksg.predict(X_train_ksg)
-    test_predictions_ksg = model_ksg.predict(X_test_ksg)
-    r2_insample_ksg = r2_score(y_true=y_train, y_pred=train_predictions_ksg)
-    r2_outsample_ksg = r2_score(y_true=y_test, y_pred=test_predictions_ksg)
+    r2_insample_ksg, r2_outsample_ksg = train_and_evaluate(
+        X_train, y_train,
+        X_val, y_val,
+        X_test, y_test,
+        selection=ksg_selection,
+    )
     print('\nKSG')
     print(f'Number of features: {len(ksg_selection)}')
     print(
@@ -79,14 +97,12 @@ def main():
         f'Out-sample R2 score with KSG selection: {round(r2_outsample_ksg, 4)}')
 
     # ## Accuracy of prediction based on HSIC selection
-    X_train_hsic = X_train.loc[:, hsic_selection]
-    X_test_hsic = X_test.loc[:, hsic_selection]
-    model_hsic = CatBoostRegressor(**params)
-    model_hsic.fit(X_train_hsic, y_train)
-    train_predictions_hsic = model_hsic.predict(X_train_hsic)
-    test_predictions_hsic = model_hsic.predict(X_test_hsic)
-    r2_insample_hsic = r2_score(y_true=y_train, y_pred=train_predictions_hsic)
-    r2_outsample_hsic = r2_score(y_true=y_test, y_pred=test_predictions_hsic)
+    r2_insample_hsic, r2_outsample_hsic = train_and_evaluate(
+        X_train, y_train,
+        X_val, y_val,
+        X_test, y_test,
+        selection=hsic_selection,
+    )
     print('\nHSIC Lasso')
     print(f'Number of features: {len(hsic_selection)}')
     print(
@@ -95,33 +111,26 @@ def main():
         f'Out-sample R2 score with HSIC Lasso selection: {round(r2_outsample_hsic, 4)}')
 
     # ## Accuracy of prediction based on HISEL selection
-    X_train_hisel = X_train.loc[:, hisel_selection]
-    X_test_hisel = X_test.loc[:, hisel_selection]
-    model_hisel = CatBoostRegressor(**params)
-    model_hisel.fit(X_train_hisel, y_train)
-    train_predictions_hisel = model_hisel.predict(X_train_hisel)
-    test_predictions_hisel = model_hisel.predict(X_test_hisel)
-    r2_insample_hisel = r2_score(
-        y_true=y_train, y_pred=train_predictions_hisel)
-    r2_outsample_hisel = r2_score(y_true=y_test, y_pred=test_predictions_hisel)
-    print('\nHISEL Lasso')
+    r2_insample_hisel, r2_outsample_hisel = train_and_evaluate(
+        X_train, y_train,
+        X_val, y_val,
+        X_test, y_test,
+        selection=hisel_selection,
+    )
+    print('\nHISEL')
     print(f'Number of features: {len(hisel_selection)}')
     print(
-        f'In-sample R2 score with HISEL Lasso selection: {round(r2_insample_hisel, 4)}')
+        f'In-sample R2 score with HISEL selection: {round(r2_insample_hisel, 4)}')
     print(
-        f'Out-sample R2 score with HISEL Lasso selection: {round(r2_outsample_hisel, 4)}')
+        f'Out-sample R2 score with HISEL selection: {round(r2_outsample_hisel, 4)}')
 
     # ## Accuracy of prediction based on boruta selection
-    X_train_boruta = X_train.loc[:, boruta_selection]
-    X_test_boruta = X_test.loc[:, boruta_selection]
-    model_boruta = CatBoostRegressor(**params)
-    model_boruta.fit(X_train_boruta, y_train)
-    train_predictions_boruta = model_boruta.predict(X_train_boruta)
-    test_predictions_boruta = model_boruta.predict(X_test_boruta)
-    r2_insample_boruta = r2_score(
-        y_true=y_train, y_pred=train_predictions_boruta)
-    r2_outsample_boruta = r2_score(
-        y_true=y_test, y_pred=test_predictions_boruta)
+    r2_insample_boruta, r2_outsample_boruta = train_and_evaluate(
+        X_train, y_train,
+        X_val, y_val,
+        X_test, y_test,
+        selection=boruta_selection,
+    )
     print('\nBORUTA')
     print(f'Number of features: {len(boruta_selection)}')
     print(
@@ -130,38 +139,18 @@ def main():
         f'Out-sample R2 score with Boruta selection: {round(r2_outsample_boruta, 4)}')
 
     # ## Accuracy of prediction based on minerva selection
-    X_train_minerva = X_train.loc[:, minerva_filtered_selection_1]
-    X_test_minerva = X_test.loc[:, minerva_filtered_selection_1]
-    model_minerva = CatBoostRegressor(**params)
-    model_minerva.fit(X_train_minerva, y_train)
-    train_predictions_minerva = model_minerva.predict(X_train_minerva)
-    test_predictions_minerva = model_minerva.predict(X_test_minerva)
-    r2_insample_minerva = r2_score(
-        y_true=y_train, y_pred=train_predictions_minerva)
-    r2_outsample_minerva = r2_score(
-        y_true=y_test, y_pred=test_predictions_minerva)
+    r2_insample_minerva, r2_outsample_minerva = train_and_evaluate(
+        X_train, y_train,
+        X_val, y_val,
+        X_test, y_test,
+        selection=minerva_filtered_selection_1,
+    )
     print('\nMINERVA')
     print(f'Number of features: {len(minerva_filtered_selection_1)}')
     print(
         f'In-sample R2 score with Minerva selection: {round(r2_insample_minerva, 4)}')
     print(
         f'Out-sample R2 score with Minerva selection: {round(r2_outsample_minerva, 4)}')
-    X_train_minerva = X_train.loc[:, minerva_selection_1_adjusted]
-    X_test_minerva = X_test.loc[:, minerva_selection_1_adjusted]
-    model_minerva = CatBoostRegressor(**params)
-    model_minerva.fit(X_train_minerva, y_train)
-    train_predictions_minerva = model_minerva.predict(X_train_minerva)
-    test_predictions_minerva = model_minerva.predict(X_test_minerva)
-    r2_insample_minerva = r2_score(
-        y_true=y_train, y_pred=train_predictions_minerva)
-    r2_outsample_minerva = r2_score(
-        y_true=y_test, y_pred=test_predictions_minerva)
-    print(
-        f'Number of features in adjusted selection: {len(minerva_selection_1_adjusted)}')
-    print(
-        f'In-sample R2 score with Minerva adjusted selection: {round(r2_insample_minerva, 4)}')
-    print(
-        f'Out-sample R2 score with Minerva adjusted selection: {round(r2_outsample_minerva, 4)}')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Context

<!-- Why is this PR necessary? If available, include links to a JIRA ticket or other relevant documentation. -->
The accuracy of the feature selection in experiment 2 was assessed by looking at out-of-sample R2 scores of a `Catboost` model trained on the selected features. This training was flawed, as it did not use early stopping, and thus it was overfitting the model to the training data. 
This PR proposes to use [early_stopping_rounds](https://catboost.ai/en/docs/concepts/python-reference_catboostregressor_fit#early_stopping_rounds) to avoid overfitting. 

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
